### PR TITLE
Fix nil pointer in IsWorthRetrying

### DIFF
--- a/internal/dns/dnsanswer.go
+++ b/internal/dns/dnsanswer.go
@@ -92,10 +92,13 @@ func (da *DNSAnswer) ToString() string {
 
 // IsWorthRetrying is true if this answer is elligible for a retry
 func (da *DNSAnswer) IsWorthRetrying() bool {
-	switch da.Status {
-	case "TIMEOUT", "SERVFAIL":
-		return true // transient, worth another shot
-	default:
-		return false // permanent or deterministic mismatch
-	}
+        if da == nil {
+                return false
+        }
+        switch da.Status {
+        case "TIMEOUT", "SERVFAIL":
+                return true // transient, worth another shot
+        default:
+                return false // permanent or deterministic mismatch
+        }
 }

--- a/internal/dnsanitize/dnsanitize_test.go
+++ b/internal/dnsanitize/dnsanitize_test.go
@@ -108,6 +108,7 @@ func TestApplyResultsPaths(t *testing.T) {
     // Retry path -----------------------------------------------------------
     srv = helperServer(2)
     res.Passed = false
+    res.Answer = &dns.DNSAnswer{DNSAnswerData: dns.DNSAnswerData{Status: "TIMEOUT"}}
     applyResults(srv, &res, 2, st)
     if len(srv.PendingChecks) != 1 || srv.Checks[0].AttemptsLeft != 1 {
         t.Fatal("applyResults retry path incorrect")


### PR DESCRIPTION
## Summary
- handle nil answers in `IsWorthRetrying`
- adjust unit test to provide an answer for retry logic

## Testing
- `go test ./internal/dnsanitize -run ApplyResultsPaths -v`
- `go test ./...` *(fails: ENETUNREACH for DNS tests)*

------
https://chatgpt.com/codex/tasks/task_e_68417fc87f8c83249e6b4de1d8adda1a