### PR TITLE
Improve integration test

### DIFF
--- a/integration/tests/integration_test.go
+++ b/integration/tests/integration_test.go
@@ -1,60 +1,42 @@
 package tests
 
 import (
-    "testing"
-    "os"
-    "os/exec"
-    "path/filepath"
-    "strings"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
 )
 
-// TestIntegrationBasic builds the main package of dnsanity and runs it with
-// a simple server list input, checking output.
+// TestIntegrationBasic runs dnsanity with a simple server list input and checks
+// that the output contains those servers.
 func TestIntegrationBasic(t *testing.T) {
-    // 1) Build the main package explicitly using the module path or '.'
-    // Adjust "github.com/nil0x42/dnsanity" to match your module path if needed.
-    cmdBuild := exec.Command("go", "build", "-o", "dnsanity_bin", "github.com/nil0x42/dnsanity")
-    cmdBuild.Env = os.Environ()
+	// 1) Create a temporary file with some DNS servers.
+	tempDir := t.TempDir()
+	testServersPath := filepath.Join(tempDir, "servers.txt")
+	content := []byte("8.8.8.8\n1.1.1.1\n")
+	if err := os.WriteFile(testServersPath, content, 0644); err != nil {
+		t.Fatalf("Cannot write test server file: %v", err)
+	}
 
-    // Optionally, ensure we build from the repo's root directory.
-    // If your test runs from the root by default, you might not need this:
-    // cmdBuild.Dir = "../.."
-
-    out, err := cmdBuild.CombinedOutput()
-    if err != nil {
-        t.Fatalf("Failed to build dnsanity: %v\nOutput:\n%s", err, string(out))
-    }
-
-    // 2) Create a temporary file with some DNS servers
-    tempDir := t.TempDir()
-    testServersPath := filepath.Join(tempDir, "servers.txt")
-    content := []byte("8.8.8.8\n1.1.1.1\n")
-    if err := os.WriteFile(testServersPath, content, 0644); err != nil {
-        t.Fatalf("Cannot write test server file: %v", err)
-    }
-
-    // 3) Run the newly built binary
-    // We assume that 'main.go' uses the flags: -list, -o, etc.
-    cmdRun := exec.Command(
-		"./dnsanity_bin",
+	// 2) Execute the pre-built dnsanity binary.
+	out, code := runCLI(
+		t,
 		"-list", testServersPath,
 		"-o", "/dev/stdout",
 		"-trusted-timeout", "4",
 		"-trusted-ratelimit", "3",
 		"-trusted-max-attempts", "3",
 	)
-    cmdRun.Env = os.Environ()
-    runOut, runErr := cmdRun.CombinedOutput()
-    if runErr != nil {
-        t.Fatalf("Failed to run dnsanity: %v\nOutput:\n%s", runErr, string(runOut))
-    }
+	if code != 0 {
+		t.Fatalf("dnsanity exited with code %d\n%s", code, out)
+	}
 
-    // 4) Analyze the output
-    got := string(runOut)
-    if !strings.Contains(got, "8.8.8.8") {
-        t.Errorf("Expected output to contain 8.8.8.8, got:\n%s", got)
-    }
-    if !strings.Contains(got, "1.1.1.1") {
-        t.Errorf("Expected output to contain 1.1.1.1, got:\n%s", got)
-    }
+	// 3) Analyze the output
+	got := out
+	if !strings.Contains(got, "8.8.8.8") {
+		t.Errorf("Expected output to contain 8.8.8.8, got:\n%s", got)
+	}
+	if !strings.Contains(got, "1.1.1.1") {
+		t.Errorf("Expected output to contain 1.1.1.1, got:\n%s", got)
+	}
 }


### PR DESCRIPTION
## Summary
- use runCLI and binaryPath in integration tests
- remove redundant build step

## Testing
- `go test ./...` *(fails: dns tests require network)*

------
https://chatgpt.com/codex/tasks/task_e_684182c23cb88324901c6ca271df3ecc