### PR TITLE
Fix typo in MetricGauge comment

### DIFF
--- a/internal/report/logging.go
+++ b/internal/report/logging.go
@@ -26,7 +26,7 @@ type IOFiles struct {
 // MetricGauge tracks an integer metric (current, peak, average).
 // Not concurrency-safe.
 type MetricGauge struct {
-	Max       int   // optional: theoratical max
+	Max       int   // optional: theoretical max
 	Current   int   // last recorded value
 	Peak      int   // highest ever recorded value
 	totalSum  int64 // sum of all values logged


### PR DESCRIPTION
## Summary
- fix a typo in `MetricGauge` documentation comment

## Testing
- `go test ./...` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68418272c0ec8324bc14aeed69a3714f