### PR TITLE
Fix IP in InvalidServer test case

### DIFF
--- a/internal/dns/resolver_test.go
+++ b/internal/dns/resolver_test.go
@@ -80,7 +80,7 @@ func TestResolveDNS(t *testing.T) {
         {
             name:       "InvalidServer",
             domain:     "example.com",
-            server:     "1203.0.113.1", // TEST‑NET‑3, usually unroutable
+            server:     "203.0.113.1", // TEST‑NET‑3, usually unroutable
             timeout:    500 * time.Millisecond,
             wantStatus: ": no such host",
         },


### PR DESCRIPTION
## Summary
- correct IP address used in InvalidServer test in `resolver_test.go`

## Testing
- `go test ./...` *(fails: ENETUNREACH networking errors)*

------
https://chatgpt.com/codex/tasks/task_e_6841827f5b30832485ecbdc4d2d8b037